### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Project Health Check
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/blaudden/mtbo-sajten/security/code-scanning/12](https://github.com/blaudden/mtbo-sajten/security/code-scanning/12)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions used by this workflow to the least privilege necessary. For a simple CI workflow that only checks out code and runs local commands (install, build, test) without modifying repository resources, the minimal required permission is `contents: read`. This should be added either at the workflow root (applied to all jobs) or specifically under the `check` job.

The best fix here, without altering behavior, is to add a root-level `permissions` block directly under the `name` (or above `jobs:`). This documents that the workflow only needs read access to repository contents and ensures it remains restricted even if repository defaults change. Concretely, edit `.github/workflows/ci.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `name:` and the `on:` section (or anywhere at the top level before `jobs:`). No additional imports or methods are required; this is purely a configuration change within the YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
