### PR TITLE
Incomplete string escaping or encoding

### DIFF
--- a/scripts/fetch-youtube.ts
+++ b/scripts/fetch-youtube.ts
@@ -35,6 +35,10 @@ async function extractFrame(videoUrl: string, timestamp: string, outputPath: str
   });
 }
 
+function escapeForDoubleQuotedString(input: string): string {
+  return input.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
 async function main() {
   const url = process.argv[2];
   if (!url) {
@@ -105,7 +109,7 @@ async function main() {
 
     // Create index.mdoc
     const mdocContent = `---
-title: "${title.replace(/"/g, '\\"')}"
+title: "${escapeForDoubleQuotedString(title)}"
 draft: true
 publishDate: ${publishDate || new Date().toISOString().split('T')[0]}
 excerpt: "REPLACE_WITH_SUMMARY"
@@ -115,7 +119,7 @@ author: "Magnus Blåudd"
 
 REPLACE_WITH_INTRO_TEXT
 
-{% YoutubeVideo videoid="${videoId}" title="${title.replace(/"/g, '\\"')}" /%}
+{% YoutubeVideo videoid="${videoId}" title="${escapeForDoubleQuotedString(title)}" /%}
 
 REPLACE_WITH_DESCRIPTION
 ${description ? `<!-- \nDescription from YouTube:\n${description}\n-->` : ''}


### PR DESCRIPTION
Potential fix for [https://github.com/blaudden/mtbo-sajten/security/code-scanning/10](https://github.com/blaudden/mtbo-sajten/security/code-scanning/10)

To fix this, the escaping of `title` should handle both backslashes and double quotes in one place, so that the value is safe to place inside double-quoted strings in the generated `.mdoc` file and the `{% YoutubeVideo ... %}` tag. The general approach is to first escape backslashes (so existing backslashes don’t interfere with later escapes) and then escape double quotes, or to use a helper function that performs both replacements using a global regular expression.

The best way to fix this without changing functionality is to introduce a small helper function (within `scripts/fetch-youtube.ts`) that takes a string and returns a version safe for inclusion in double-quoted literals in this context. For example:

```ts
function escapeForDoubleQuotedString(input: string): string {
  return input.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
}
```

Then, replace both occurrences of `title.replace(/"/g, '\\"')` in the `mdocContent` template literal (lines 108 and 118) with `escapeForDoubleQuotedString(title)`. This keeps behavior for quotes the same while adding correct backslash escaping. No new external dependencies or imports are needed; the helper can be defined above `main` in the same file.

Concretely:
- Add the helper function somewhere above `main` (for instance after `extractFrame`).
- Update line 108 inside the template literal to: `title: "${escapeForDoubleQuotedString(title)}"`.
- Update line 118 to: `{% YoutubeVideo videoid="${videoId}" title="${escapeForDoubleQuotedString(title)}" /%}`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
