### PR TITLE
Incomplete multi-character sanitization

### DIFF
--- a/tests/check-links.mjs
+++ b/tests/check-links.mjs
@@ -66,8 +66,9 @@ function extractLinks(filePath) {
     const rawUrl = match[2];
     const linkText = match[3]
       .replace(/<[^>]*>/g, '')
+      .replace(/[<>]/g, '')
       .trim()
-      .substring(0, 50); // Strip HTML tags from text
+      .substring(0, 50); // Strip HTML tags and angle brackets from text
 
     if (rawUrl.startsWith('#') || rawUrl.startsWith('mailto:') || rawUrl.startsWith('tel:')) continue;
 


### PR DESCRIPTION
Potential fix for [https://github.com/blaudden/mtbo-sajten/security/code-scanning/6](https://github.com/blaudden/mtbo-sajten/security/code-scanning/6)

In general, to fix incomplete multi-character sanitization, either use a well-tested sanitization library or ensure that your sanitization logic cannot leave behind unsafe substrings after a single pass. That can be done by repeatedly applying the regex until no more matches occur, or by using simpler character-level patterns that remove all potentially dangerous characters such as `<` and `>`.

For this code, the simplest and safest improvement without changing existing functionality is to ensure that no literal `<` or `>` characters remain in `linkText` after we strip tags. The current regex removes balanced-looking tags (`<something>`), but it can fail on malformed or nested sequences that could leave raw `<` behind. After stripping tags with the existing regex, we can add a second replacement that removes any remaining `<` or `>` characters. This preserves the intent—derive a plain-text diagnostic preview of the link text—while eliminating the potential for residual tag delimiters that could be interpreted as HTML in any downstream consumer.

Concretely, in `tests/check-links.mjs` at the `linkText` definition (around lines 67–70), we will extend the transformation chain: after `.replace(/<[^>]*>/g, '')`, we will add `.replace(/[<>]/g, '')` before `.trim()`. No new imports or helper functions are needed; this is a pure string method change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
