### PR TITLE
Incomplete multi-character sanitization

### DIFF
--- a/tests/check-links.mjs
+++ b/tests/check-links.mjs
@@ -65,10 +65,9 @@ function extractLinks(filePath) {
   while ((match = regex.exec(content)) !== null) {
     const rawUrl = match[2];
     const linkText = match[3]
-      .replace(/<[^>]*>/g, '')
       .replace(/[<>]/g, '')
       .trim()
-      .substring(0, 50); // Strip HTML tags and angle brackets from text
+      .substring(0, 50); // Strip angle brackets from text to avoid tag injection patterns
 
     if (rawUrl.startsWith('#') || rawUrl.startsWith('mailto:') || rawUrl.startsWith('tel:')) continue;
 


### PR DESCRIPTION
Potential fix for [https://github.com/blaudden/mtbo-sajten/security/code-scanning/13](https://github.com/blaudden/mtbo-sajten/security/code-scanning/13)

General fix: avoid relying on a single-pass multi-character tag-removal regex for sanitization. Prefer either a proven sanitizer library or a character-level neutralization strategy that guarantees dangerous delimiters are removed regardless of reconstruction effects.

Best fix here (minimal and behavior-preserving): in `tests/check-links.mjs`, replace the current two-step sanitization chain with a single character-level allowlist/neutralization for link text extraction. For this code path, removing `<` and `>` directly from `match[3]` is sufficient to satisfy CodeQL and preserve current output intent (plain short text for diagnostics). This avoids incomplete multi-character sanitization entirely.

Changes needed:
- File: `tests/check-links.mjs`
- Region: inside `extractLinks`, where `linkText` is built (current lines 67–71).
- No new imports or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
