### PR TITLE
Double escaping or unescaping

### DIFF
--- a/tests/verify-meta-descriptions.mjs
+++ b/tests/verify-meta-descriptions.mjs
@@ -23,12 +23,12 @@ function getAllHtmlFiles(dir, fileList = []) {
 
 function decodeEntities(text) {
   return text
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
-    .replace(/&#x27;/g, "'");
+    .replace(/&#x27;/g, "'")
+    .replace(/&amp;/g, '&');
 }
 
 function verifyMetaDescriptions() {


### PR DESCRIPTION
Potential fix for [https://github.com/blaudden/mtbo-sajten/security/code-scanning/4](https://github.com/blaudden/mtbo-sajten/security/code-scanning/4)

In general, to avoid double unescaping when dealing with entity sequences, the escape character (`&` for HTML entities) must be unescaped last. That way, sequences like `&amp;lt;` remain as literal text (`&lt;`) rather than being turned into `<`. Conversely, when escaping, `&` must be escaped first. For this code, the minimal safe fix is to adjust `decodeEntities` so that all specific entities (`&lt;`, `&gt;`, `&quot;`, `&#39;`, `&#x27;`) are unescaped before `&amp;`.

Concretely, in `tests/verify-meta-descriptions.mjs`, we should reorder the `.replace` calls inside `decodeEntities` so that the replacements for `&lt;`, `&gt;`, `&quot;`, `&#39;`, and `&#x27;` come before the replacement for `&amp;`. No new imports or helper methods are necessary, and the rest of the file remains unchanged. This preserves functionality (converting a handful of HTML entities back to characters for length checking) while eliminating the double-unescape pattern reported by CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
