### PR TITLE
Resolve broken Eventor storage document links via serverless resolver fallback

### DIFF
--- a/netlify/functions/resolve-eventor-storage.mts
+++ b/netlify/functions/resolve-eventor-storage.mts
@@ -1,0 +1,124 @@
+import type { Config } from '@netlify/functions';
+
+export default async (request: Request) => {
+  const requestUrl = new URL(request.url);
+  const docUrl = requestUrl.searchParams.get('url');
+  const eventorUrl = requestUrl.searchParams.get('eventorUrl');
+
+  if (!docUrl || !eventorUrl) {
+    return new Response('Missing parameters', {
+      status: 400,
+      headers: {
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+      },
+    });
+  }
+
+  // Check if the original URL is valid using a fast HEAD request
+  try {
+    const checkResponse = await fetch(docUrl, {
+      method: 'HEAD',
+      signal: AbortSignal.timeout(3000),
+    });
+
+    if (checkResponse.ok) {
+      console.log(`Live check: original document URL is valid. Redirecting: ${docUrl}`);
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: docUrl,
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+        },
+      });
+    }
+  } catch (e) {
+    console.warn(`Live check HEAD request failed for ${docUrl}:`, e);
+  }
+
+  // Extract the Eventor event ID from the event URL path
+  const eventIdMatch = eventorUrl.match(/\/Events\/Show\/(\d+)/i);
+  const eventId = eventIdMatch ? eventIdMatch[1] : null;
+  const urlParts = docUrl.split('/');
+  const filename = urlParts[urlParts.length - 1];
+
+  if (eventId && filename) {
+    try {
+      const eventorResponse = await fetch(eventorUrl, {
+        signal: AbortSignal.timeout(5000),
+      });
+
+      if (eventorResponse.ok) {
+        const html = await eventorResponse.text();
+
+        // Extract all Eventor storage URLs from the HTML
+        const hrefRegex = /href="([^"]*eventdocuments\/\d+\/[^"]+)"/gi;
+        const foundUrls: string[] = [];
+        let match;
+        while ((match = hrefRegex.exec(html)) !== null) {
+          foundUrls.push(match[1]);
+        }
+
+        const targetFilename = decodeURIComponent(filename).toLowerCase();
+
+        // Strategy A: Exact case-insensitive filename match
+        let matchedUrl = foundUrls.find((u) => {
+          try {
+            const decoded = decodeURIComponent(u);
+            const parts = decoded.split('/');
+            const fname = parts[parts.length - 1].toLowerCase();
+            return fname === targetFilename;
+          } catch {
+            return false;
+          }
+        });
+
+        // Strategy B: Fallback substring match on the base filename
+        if (!matchedUrl) {
+          const dotIndex = targetFilename.lastIndexOf('.');
+          const baseName = dotIndex !== -1 ? targetFilename.substring(0, dotIndex) : targetFilename;
+          if (baseName.length > 2) {
+            matchedUrl = foundUrls.find((u) => {
+              try {
+                const decoded = decodeURIComponent(u);
+                const parts = decoded.split('/');
+                const fname = parts[parts.length - 1].toLowerCase();
+                return fname.includes(baseName);
+              } catch {
+                return false;
+              }
+            });
+          }
+        }
+
+        if (matchedUrl) {
+          // HTML entities might be encoded, decode them if needed
+          const newDocUrl = matchedUrl.replace(/&amp;/g, '&');
+          console.log(`Resolved broken document URL ${docUrl} to ${newDocUrl} via Eventor page scraping`);
+          return new Response(null, {
+            status: 302,
+            headers: {
+              Location: newDocUrl,
+              'Cache-Control': 'no-cache, no-store, must-revalidate',
+            },
+          });
+        }
+      }
+    } catch (e) {
+      console.error(`Failed to scrape Eventor event page ${eventorUrl}:`, e);
+    }
+  }
+
+  // Fallback to Eventor event page
+  console.log(`Could not resolve document URL ${docUrl}. Redirecting to Eventor event page fallback: ${eventorUrl}`);
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: eventorUrl,
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+    },
+  });
+};
+
+export const config: Config = {
+  path: '/api/resolve-eventor-storage',
+};

--- a/src/components/events/EventDocuments.astro
+++ b/src/components/events/EventDocuments.astro
@@ -4,7 +4,7 @@
  */
 import { Icon } from 'astro-icon/components';
 import { Image } from 'astro:assets';
-import { resolveRelativeUrl, getSmartIconInfo, getRaceTerminology } from '~/utils/events';
+import { resolveRelativeUrl, getSmartIconInfo, getRaceTerminology, resolveExternalUrl } from '~/utils/events';
 import type { ScraperEvent } from '~/types/events';
 import liveloxIcon from '~/assets/images/livelox-icon.png';
 
@@ -18,6 +18,16 @@ const { event } = Astro.props;
 const documents: Array<{ title: string; url: string; type: string }> = [];
 const seenUrls = new Set<string>();
 
+// Helper to check and wrap Eventor storage URLs with the live resolver function
+function wrapEventorUrl(url: string): string {
+  const eventorMatch = url.match(/eventor-[a-zA-Z0-9_-]+-storage\.[a-zA-Z0-9.-]+\/eventdocuments\/(\d+)\//i);
+  if (eventorMatch) {
+    const eventorUrl = resolveExternalUrl(event) || '';
+    return `/api/resolve-eventor-storage?url=${encodeURIComponent(url)}&eventorUrl=${encodeURIComponent(eventorUrl)}`;
+  }
+  return url;
+}
+
 // Add event-level documents
 for (const doc of event.documents || []) {
   if (doc.type === 'EmbargoMap' && !doc.url.startsWith('http')) continue;
@@ -26,7 +36,7 @@ for (const doc of event.documents || []) {
     seenUrls.add(resolvedUrl);
     documents.push({
       title: doc.title,
-      url: resolvedUrl,
+      url: wrapEventorUrl(resolvedUrl),
       type: doc.type,
     });
   }
@@ -46,7 +56,7 @@ for (let i = 0; i < event.races.length; i++) {
       seenUrls.add(resolvedUrl);
       documents.push({
         title: prefix + doc.title,
-        url: resolvedUrl,
+        url: wrapEventorUrl(resolvedUrl),
         type: doc.type,
       });
     }


### PR DESCRIPTION
When an event organizer uploads a new version of an invitation, PM, or other race document in Eventor, it generates a new UUID for the file path. The static event links stored in the repository's events database will resolve to 404 errors until the next scheduled scraping and deployment run finishes.

CORS restrictions enforce that client-side JavaScript running in the user's browser cannot check cross-origin URL status or fetch the Eventor pages to find updated URLs directly. Introducing a serverless resolver function allows executing these check requests server-side without CORS limitations.

This patch routes all Eventor storage URLs (across all countries and IOF) through a new /api/resolve-eventor-storage serverless function. When requested, it verifies the document link's status and automatically scrapes the corresponding Eventor event page (built dynamically using the caller-provided Eventor URL parameter) for the updated document URL if the original link is broken, falling back gracefully to the main event page if no match is found.
